### PR TITLE
feat: operator overloads on ziapi::Version struct

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ set(TEST_SOURCES
     tests/Compressor.cpp
     tests/Decompressor.cpp
     tests/Module.cpp
+    tests/Version.cpp
 )
 
 add_executable(${BIN}

--- a/include/ziapi/Version.hpp
+++ b/include/ziapi/Version.hpp
@@ -17,6 +17,8 @@ struct Version {
 
     inline bool operator>(const Version &other) const noexcept
     {
+        if (this->major > other.major)
+            return true;
         if (this->major < other.major)
             return false;
         return this->minor > other.minor;
@@ -24,24 +26,16 @@ struct Version {
 
     inline bool operator<(const Version &other) const noexcept
     {
+        if (this->major < other.major)
+            return true;
         if (this->major > other.major)
             return false;
         return this->minor < other.minor;
     }
 
-    inline bool operator>=(const Version &other) const noexcept
-    {
-        if (this->major < other.major)
-            return false;
-        return this->minor <= other.minor;
-    }
+    inline bool operator>=(const Version &other) const noexcept { return (*this > other) || (*this == other); }
 
-    inline bool operator<=(const Version &other) const noexcept
-    {
-        if (this->major > other.major)
-            return false;
-        return this->minor >= other.minor;
-    }
+    inline bool operator<=(const Version &other) const noexcept { return (*this < other) || (*this == other); }
 
     unsigned int major;
     unsigned int minor;

--- a/include/ziapi/Version.hpp
+++ b/include/ziapi/Version.hpp
@@ -8,9 +8,40 @@ namespace ziapi {
 struct Version {
     Version(int major, int minor) : major(major), minor(minor) {}
 
-    bool operator==(const Version &other) const { return this->major == other.major && this->minor == other.minor; }
+    inline bool operator==(const Version &other) const noexcept
+    {
+        return this->major == other.major && this->minor == other.minor;
+    }
 
-    bool operator!=(const Version &other) const { return this->major != other.major || this->minor != other.minor; }
+    inline bool operator!=(const Version &other) const noexcept { return !(*this == other); }
+
+    inline bool operator>(const Version &other) const noexcept
+    {
+        if (this->major < other.major)
+            return false;
+        return this->minor > other.minor;
+    }
+
+    inline bool operator<(const Version &other) const noexcept
+    {
+        if (this->major > other.major)
+            return false;
+        return this->minor < other.minor;
+    }
+
+    inline bool operator>=(const Version &other) const noexcept
+    {
+        if (this->major < other.major)
+            return false;
+        return this->minor <= other.minor;
+    }
+
+    inline bool operator<=(const Version &other) const noexcept
+    {
+        if (this->major > other.major)
+            return false;
+        return this->minor >= other.minor;
+    }
 
     unsigned int major;
     unsigned int minor;

--- a/include/ziapi/Version.hpp
+++ b/include/ziapi/Version.hpp
@@ -17,11 +17,11 @@ struct Version {
 
     inline bool operator>(const Version &other) const noexcept
     {
-        if (this->major > other.major)
+        if (major > other.major)
             return true;
-        if (this->major < other.major)
+        if (major < other.major)
             return false;
-        return this->minor > other.minor;
+        return minor > other.minor;
     }
 
     inline bool operator<(const Version &other) const noexcept

--- a/include/ziapi/Version.hpp
+++ b/include/ziapi/Version.hpp
@@ -10,7 +10,7 @@ struct Version {
 
     inline bool operator==(const Version &other) const noexcept
     {
-        return this->major == other.major && this->minor == other.minor;
+        return major == other.major && minor == other.minor;
     }
 
     inline bool operator!=(const Version &other) const noexcept { return !(*this == other); }

--- a/include/ziapi/Version.hpp
+++ b/include/ziapi/Version.hpp
@@ -26,11 +26,11 @@ struct Version {
 
     inline bool operator<(const Version &other) const noexcept
     {
-        if (this->major < other.major)
+        if (major < other.major)
             return true;
-        if (this->major > other.major)
+        if (major > other.major)
             return false;
-        return this->minor < other.minor;
+        return minor < other.minor;
     }
 
     inline bool operator>=(const Version &other) const noexcept { return (*this > other) || (*this == other); }

--- a/tests/Version.cpp
+++ b/tests/Version.cpp
@@ -1,0 +1,111 @@
+#include "ziapi/Version.hpp"
+
+#include <gtest/gtest.h>
+
+TEST(Version, equal)
+{
+    ziapi::Version a{1, 0};
+    ziapi::Version b{1, 0};
+
+    ASSERT_TRUE(a == b);
+
+    a = ziapi::Version{1, 1};
+    b = ziapi::Version{1, 0};
+
+    ASSERT_FALSE(a == b);
+
+    a = ziapi::Version{2, 0};
+    b = ziapi::Version{1, 1};
+
+    ASSERT_FALSE(a == b);
+}
+
+TEST(Version, not_equal)
+{
+    ziapi::Version a{1, 0};
+    ziapi::Version b{1, 0};
+
+    ASSERT_FALSE(a != b);
+
+    a = ziapi::Version{1, 1};
+    b = ziapi::Version{1, 0};
+
+    ASSERT_TRUE(a != b);
+
+    a = ziapi::Version{2, 0};
+    b = ziapi::Version{1, 1};
+
+    ASSERT_TRUE(a != b);
+}
+
+TEST(Version, upper)
+{
+    ziapi::Version a{1, 0};
+    ziapi::Version b{1, 0};
+
+    ASSERT_FALSE(a > b);
+
+    a = ziapi::Version{1, 1};
+    b = ziapi::Version{1, 0};
+
+    ASSERT_TRUE(a > b);
+
+    a = ziapi::Version{2, 0};
+    b = ziapi::Version{3, 1};
+
+    ASSERT_FALSE(a > b);
+}
+
+TEST(Version, lower)
+{
+    ziapi::Version a{1, 0};
+    ziapi::Version b{1, 0};
+
+    ASSERT_FALSE(a < b);
+
+    a = ziapi::Version{1, 1};
+    b = ziapi::Version{3, 4};
+
+    ASSERT_TRUE(a < b);
+
+    a = ziapi::Version{2, 0};
+    b = ziapi::Version{1, 0};
+
+    ASSERT_FALSE(a < b);
+}
+
+TEST(Version, upper_eq)
+{
+    ziapi::Version a{1, 0};
+    ziapi::Version b{1, 0};
+
+    ASSERT_TRUE(a >= b);
+
+    a = ziapi::Version{3, 1};
+    b = ziapi::Version{1, 4};
+
+    ASSERT_TRUE(a >= b);
+
+    a = ziapi::Version{1, 6};
+    b = ziapi::Version{3, 6};
+
+    ASSERT_FALSE(a >= b);
+}
+
+TEST(Version, lower_eq)
+{
+    ziapi::Version a{1, 0};
+    ziapi::Version b{1, 0};
+
+    ASSERT_TRUE(a <= b);
+
+    a = ziapi::Version{1, 1};
+    b = ziapi::Version{3, 1};
+
+    ASSERT_TRUE(a <= b);
+
+    a = ziapi::Version{2, 4};
+    b = ziapi::Version{1, 7};
+
+    ASSERT_FALSE(a <= b);
+}

--- a/tests/Version.cpp
+++ b/tests/Version.cpp
@@ -74,7 +74,7 @@ TEST(Version, less)
     ASSERT_FALSE(a < b);
 }
 
-TEST(Version, upper_eq)
+TEST(Version, greater_or_equal)
 {
     ziapi::Version a{1, 0};
     ziapi::Version b{1, 0};

--- a/tests/Version.cpp
+++ b/tests/Version.cpp
@@ -38,7 +38,7 @@ TEST(Version, not_equal)
     ASSERT_TRUE(a != b);
 }
 
-TEST(Version, upper)
+TEST(Version, greater)
 {
     ziapi::Version a{1, 0};
     ziapi::Version b{1, 0};

--- a/tests/Version.cpp
+++ b/tests/Version.cpp
@@ -92,7 +92,7 @@ TEST(Version, greater_or_equal)
     ASSERT_FALSE(a >= b);
 }
 
-TEST(Version, lower_eq)
+TEST(Version, less_or_equal)
 {
     ziapi::Version a{1, 0};
     ziapi::Version b{1, 0};

--- a/tests/Version.cpp
+++ b/tests/Version.cpp
@@ -56,7 +56,7 @@ TEST(Version, greater)
     ASSERT_FALSE(a > b);
 }
 
-TEST(Version, lower)
+TEST(Version, less)
 {
     ziapi::Version a{1, 0};
     ziapi::Version b{1, 0};


### PR DESCRIPTION
# Description

Operator overloads on `ziapi::Version` struct
Unit tests relative to `ziapi::Version` operators

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have tested this code
- [X] I have added sufficient documentation in the code