### PR TITLE
fix: build error due to missing header (unordered_map)

### DIFF
--- a/include/ziapi/Http.hpp
+++ b/include/ziapi/Http.hpp
@@ -2,6 +2,7 @@
 
 #include <any>
 #include <map>
+#include <unordered_map>
 #include <string>
 
 #include "HttpConstants.hpp"

--- a/include/ziapi/Module.hpp
+++ b/include/ziapi/Module.hpp
@@ -57,7 +57,7 @@ public:
  *  Post processor modules are invoked after the generation of the response
  *  by the handler module. They can be used for logging, cors, compression, etc...
  */
-class IPostProcessorModule : public IModule {
+class IPostProcessorModule : virtual public IModule {
 public:
     virtual ~IPostProcessorModule() = default;
     /**
@@ -81,7 +81,7 @@ public:
  *  Pre processor modules are invoked before the generation of the response by
  *  the handler module. They can be used for url rewriting, authentication, logging, etc...
  */
-class IPreProcessorModule : public IModule {
+class IPreProcessorModule : virtual public IModule {
 public:
     virtual ~IPreProcessorModule() = default;
     /**


### PR DESCRIPTION
# Description

Fix compilation error due to missing header in Http.hpp .

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes


# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [x] I have added sufficient documentation in the code

# Additional comments