### PR TITLE
IResponseInputQueue interface changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(googletest QUIET)
 include(FetchContent)
 FetchContent_Declare(
 	googletest
-	URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
+	URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip
 )
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)

--- a/include/ziapi/Http.hpp
+++ b/include/ziapi/Http.hpp
@@ -59,7 +59,7 @@ class IResponseInputQueue {
 public:
     virtual ~IResponseInputQueue() = default;
 
-    virtual bool Pop(std::pair<Request, Context> &req) = 0;
+    virtual std::pair<std::pair<Request, Context>, bool> Pop() = 0;
 
     [[nodiscard]] virtual std::size_t Size() const noexcept = 0;
 };

--- a/include/ziapi/Http.hpp
+++ b/include/ziapi/Http.hpp
@@ -59,7 +59,7 @@ class IResponseInputQueue {
 public:
     virtual ~IResponseInputQueue() = default;
 
-    virtual std::pair<Request, Context> Pop() = 0;
+    virtual bool Pop(std::pair<Request, Context> &req) = 0;
 
     [[nodiscard]] virtual std::size_t Size() const noexcept = 0;
 };


### PR DESCRIPTION
# Description

fix #12 

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

```cpp
virtual std::pair<Request, Context> IResponseInputQueue::Pop() = 0;
```
becomes

```cpp
virtual bool IResponseInputQueue::Pop(std::pair<Request, Context> &req) = 0;
```

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [x] I have added sufficient documentation in the code

# Additional comments