### PR TITLE
Using enum class instead of list of constants

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ find_package(googletest QUIET)
 include(FetchContent)
 FetchContent_Declare(
 	googletest
-	URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
+	URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip
 )
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)

--- a/include/ziapi/Http.hpp
+++ b/include/ziapi/Http.hpp
@@ -43,7 +43,7 @@ struct Response {
 
     std::string body;
 
-    void Bootstrap(int status_code = code::OK, std::string reason = reason::OK, int version = version::V1_1);
+    void Bootstrap(int status_code = CODE::OK, std::string reason = reason::OK, int version = VERSION::V1_1);
 };
 
 /**

--- a/include/ziapi/HttpConstants.hpp
+++ b/include/ziapi/HttpConstants.hpp
@@ -14,14 +14,12 @@ constexpr auto HEAD = "HEAD";
 
 }  // namespace method
 
-namespace version {
-
-constexpr auto V1 = 10;
-constexpr auto V1_1 = 11;
-constexpr auto V2 = 20;
-constexpr auto V3 = 30;
-
-}  // namespace version
+enum class VERSION {
+    V1 = 10,
+    V1_1 = 11,
+    V2 = 20,
+    V3 = 30,
+};
 
 namespace header {
 
@@ -149,49 +147,47 @@ constexpr auto HTTP_VERSION_NOT_SUPPORTED = "HTTP Version not supported";
 
 }  // namespace reason
 
-namespace code {
-
-constexpr auto CONTINUE = 100;
-constexpr auto SWITCHING_PROTOCOLS = 101;
-constexpr auto OK = 200;
-constexpr auto CREATED = 201;
-constexpr auto ACCEPTED = 202;
-constexpr auto NON_AUTHORITATIVE_INFORMATION = 203;
-constexpr auto NO_CONTENT = 204;
-constexpr auto RESET_CONTENT = 205;
-constexpr auto PARTIAL_CONTENT = 206;
-constexpr auto MULTIPLE_CHOICES = 300;
-constexpr auto MOVED_PERMANENTLY = 301;
-constexpr auto FOUND = 302;
-constexpr auto SEE_OTHER = 303;
-constexpr auto NOT_MODIFIED = 304;
-constexpr auto USE_PROXY = 305;
-constexpr auto TEMPORARY_REDIRECT = 307;
-constexpr auto BAD_REQUEST = 400;
-constexpr auto UNAUTHORIZED = 401;
-constexpr auto PAYMENT_REQUIRED = 402;
-constexpr auto FORBIDDEN = 403;
-constexpr auto NOT_FOUND = 404;
-constexpr auto METHOD_NOT_ALLOWED = 405;
-constexpr auto NOT_ACCEPTABLE = 406;
-constexpr auto PROXY_AUTHENTICATION_REQUIRED = 407;
-constexpr auto REQUEST_TIME_OUT = 408;
-constexpr auto CONFLICT = 409;
-constexpr auto GONE = 410;
-constexpr auto LENGTH_REQUIRED = 411;
-constexpr auto PRECONDITION_FAILED = 412;
-constexpr auto REQUEST_ENTITY_TOO_LARGE = 413;
-constexpr auto REQUEST_URI_TOO_LARGE = 414;
-constexpr auto UNSUPPORTED_MEDIA_TYPE = 415;
-constexpr auto REQUESTED_RANGE_NOT_SATISFIABLE = 416;
-constexpr auto EXPECTATION_FAILED = 417;
-constexpr auto INTERNAL_SERVER_ERROR = 500;
-constexpr auto NOT_IMPLEMENTED = 501;
-constexpr auto BAD_GATEWAY = 502;
-constexpr auto SERVICE_UNAVAILABLE = 503;
-constexpr auto GATEWAY_TIME_OUT = 504;
-constexpr auto HTTP_VERSION_NOT_SUPPORTED = 505;
-
-}  // namespace code
+enum class CODE {
+    CONTINUE = 100,
+    SWITCHING_PROTOCOLS = 101,
+    OK = 200,
+    CREATED = 201,
+    ACCEPTED = 202,
+    NON_AUTHORITATIVE_INFORMATION = 203,
+    NO_CONTENT = 204,
+    RESET_CONTENT = 205,
+    PARTIAL_CONTENT = 206,
+    MULTIPLE_CHOICES = 300,
+    MOVED_PERMANENTLY = 301,
+    FOUND = 302,
+    SEE_OTHER = 303,
+    NOT_MODIFIED = 304,
+    USE_PROXY = 305,
+    TEMPORARY_REDIRECT = 307,
+    BAD_REQUEST = 400,
+    UNAUTHORIZED = 401,
+    PAYMENT_REQUIRED = 402,
+    FORBIDDEN = 403,
+    NOT_FOUND = 404,
+    METHOD_NOT_ALLOWED = 405,
+    NOT_ACCEPTABLE = 406,
+    PROXY_AUTHENTICATION_REQUIRED = 407,
+    REQUEST_TIME_OUT = 408,
+    CONFLICT = 409,
+    GONE = 410,
+    LENGTH_REQUIRED = 411,
+    PRECONDITION_FAILED = 412,
+    REQUEST_ENTITY_TOO_LARGE = 413,
+    REQUEST_URI_TOO_LARGE = 414,
+    UNSUPPORTED_MEDIA_TYPE = 415,
+    REQUESTED_RANGE_NOT_SATISFIABLE = 416,
+    EXPECTATION_FAILED = 417,
+    INTERNAL_SERVER_ERROR = 500,
+    NOT_IMPLEMENTED = 501,
+    BAD_GATEWAY = 502,
+    SERVICE_UNAVAILABLE = 503,
+    GATEWAY_TIME_OUT = 504,
+    HTTP_VERSION_NOT_SUPPORTED = 505,
+};
 
 }  // namespace ziapi::http


### PR DESCRIPTION
# Description

As the constants defined as int were set using lists of int instead of
using enum class, it's been replaced so that it is cleaner and
corresponds more to the standard stuff done in C++

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [x] I have tested this code
- [x] I have added sufficient documentation in the code

closes #14 