### PR TITLE
Feat/build conf vectors

### DIFF
--- a/docs/guides/CONFIG.md
+++ b/docs/guides/CONFIG.md
@@ -83,7 +83,7 @@ auto obj = Node::MakeDict({
 // You can also give the helper methods a vector representing your array or dictionnary
 // The helper functions will automatically transform your contained Nodes into shared_ptr   
 
-std::vector<std::pair<std::string, Node>> dictionnary_vector;
+std::unordered_map<std::string, Node> dictionnary_vector;
 // ... Fill the dictionnary vector
 Node dictionnary_node = Node::MakeDict(dictionnary_vector)
 

--- a/docs/guides/CONFIG.md
+++ b/docs/guides/CONFIG.md
@@ -47,6 +47,8 @@ You could represent it using a `ziapi::config::Node` like so
 
 ```cpp
 using Node = ziapi::config::Node;
+using Dict = ziapi::config::Dict;
+using Array = ziapi::config::Array;
 
 Node obj(
     {
@@ -75,7 +77,31 @@ auto obj = Node::MakeDict({
         })}
     })}
 })
+```
+### More informations about Dict and Array helper functions
+```cpp
+// You can also give the helper methods a vector representing your array or dictionnary
+// The helper functions will automatically transform your contained Nodes into shared_ptr   
 
+std::vector<std::pair<std::string, Node>> dictionnary_vector;
+// ... Fill the dictionnary vector
+Node dictionnary_node = Node::MakeDict(dictionnary_vector)
+
+std::vector<Node> array_vector;
+// ... Fill the array vector
+Node array_node = Node::MakeArray(array_vector)
+
+
+// You can of course build them from the Node base types
+// In this case, you're responsible of giving the values as shared_ptr and converting the final variable as a Node
+
+Dict dictionnary;
+dictionnary["modules_count"] = std::make_shared<Node>(10);
+Node dictionnary_node(dictionnary);
+
+Array arr;
+arr.emplace_back(std::make_shared("/bin/ls"));
+Node array_node(arr);
 ```
 
 ## Data Types
@@ -170,17 +196,20 @@ The `Array` data type represents an array of values. So the following JSON:
 Would translate to
 
 ```cpp
-ziapi::config::Node({
+ziapi::config::Array arr({
     std::make_shared<ziapi::config::Node>("Hello"),
     std::make_shared<ziapi::config::Node>("World"),
     std::make_shared<ziapi::config::Node>("!")
 });
+
+ziapi::config::Node arr_node(arr);
 ```
 
 Which is equivalent to
 
 ```c++
-ziapi::config::Node::MakeArray({ "Hello", "World", "!" });
+auto array_node = ziapi::config::Node::MakeArray({ "Hello", "World", "!" }); 
+// vector<Node> can also be passed as a parameter
 ```
 
 ### `Dict`
@@ -199,21 +228,23 @@ The `Dict` data type represents a dictionary of values. So the following JSON:
 Would translate to
 
 ```cpp
-ziapi::config::Node({
+ziapi::config::Dict dict({
     {"age", std::make_shared<ziapi::config::Node>(19)},
     {"first_name", std::make_shared<ziapi::config::Node>("Charlie")},
     {"last_name", std::make_shared<ziapi::config::Node>("Chou")},
     {"is_sexy", std::make_shared<ziapi::config::Node>(true)}
 })
+
+ziapi::config::Node node_dict(dict);
 ```
 
 Which is equivalent to
 
 ```c++
-ziapi::config::Node::MakeDict({
+auto node_dict = ziapi::config::Node::MakeDict({
     {"age", 19},
     {"first_name", "Charlie"},
     {"last_name", "Chou"},
     {"is_sexy", true},
-})
+}) // vector<std::string, Node> can also be passed as a parameter
 ```

--- a/include/ziapi/Config.hpp
+++ b/include/ziapi/Config.hpp
@@ -74,7 +74,7 @@ public:
     }
 
     /// Constructs a Dict node from a vector, it instantiates an std::shared_ptr for each value
-    static Node MakeDict(const std::vector<std::pair<std::string, Node>> &values)
+    static Node MakeDict(const std::unordered_map<std::string, Node> &values)
     {
         Dict dict;
 

--- a/include/ziapi/Config.hpp
+++ b/include/ziapi/Config.hpp
@@ -40,7 +40,7 @@ struct Node : public NodeVariant {
 public:
     using NodeVariant::NodeVariant;
 
-    /// Simpler way to construct a node from a Array, it instantiate std::shared_ptr by itself
+    /// Simpler way to construct an Array node, it instantiates an std::shared_ptr for each value
     static Node MakeArray(const std::initializer_list<Node> &values)
     {
         Array arr;
@@ -51,13 +51,35 @@ public:
         return arr;
     }
 
-    /// Simpler way to construct a node from a Dict, it instantiate std::shared_ptr by itself
+    /// Constructs an Array node from a vector, it instantiates an std::shared_ptr for each value
+    static Node MakeArray(const std::vector<Node> &values)
+    {
+        Array arr;
+
+        for (auto &value : values) {
+            arr.push_back(std::make_shared<Node>(value));
+        }
+        return arr;
+    }
+
+    /// Simpler way to construct a Dict node, it instantiates an std::shared_ptr for each value
     static Node MakeDict(const std::initializer_list<std::pair<std::string, Node>> &values)
     {
         Dict dict;
 
         for (auto &value : values) {
             dict[value.first] = std::make_shared<Node>(value.second);
+        }
+        return dict;
+    }
+
+    /// Constructs a Dict node from a vector, it instantiates an std::shared_ptr for each value
+    static Node MakeDict(const std::vector<std::pair<std::string, Node>> &values)
+    {
+        Dict dict;
+
+        for (auto &[key, value] : values) {
+            dict[key] = std::make_shared<Node>(value);
         }
         return dict;
     }

--- a/tests/Config.cpp
+++ b/tests/Config.cpp
@@ -83,7 +83,7 @@ TEST(Config, VectorConstructArray)
 
 TEST(Config, VectorConstructDict)
 {
-    std::vector<std::pair<std::string, Node>> vec{{"ten", 10}, {"string", "value"}, {"float", 1.f}, {"null", nullptr}};
+    std::unordered_map<std::string, Node> vec{{"ten", 10}, {"string", "value"}, {"float", 1.f}, {"null", nullptr}};
     Node n = Node::MakeDict(vec);
 
     ASSERT_EQ(n["ten"].AsInt(), 10);

--- a/tests/Config.cpp
+++ b/tests/Config.cpp
@@ -70,3 +70,24 @@ TEST(Config, OperatorBool)
     ASSERT_EQ(null.operator bool(), false);
     ASSERT_EQ(string.operator bool(), true);
 }
+
+TEST(Config, VectorConstructArray)
+{
+    std::vector<Node> vec{10, "value", 1.f};
+    Node n = Node::MakeArray(vec);
+
+    ASSERT_EQ(n[(std::size_t)0].AsInt(), 10);
+    ASSERT_EQ(n[1].AsString(), "value");
+    ASSERT_EQ(n[2].AsDouble(), 1.f);
+}
+
+TEST(Config, VectorConstructDict)
+{
+    std::vector<std::pair<std::string, Node>> vec{{"ten", 10}, {"string", "value"}, {"float", 1.f}, {"null", nullptr}};
+    Node n = Node::MakeDict(vec);
+
+    ASSERT_EQ(n["ten"].AsInt(), 10);
+    ASSERT_EQ(n["string"].AsString(), "value");
+    ASSERT_EQ(n["float"].AsDouble(), 1.f);
+    ASSERT_EQ(n["null"].IsNull(), true);
+}


### PR DESCRIPTION
# Description

MakeDict and MakeArray can now take vectors + documentation changed accordingly.
From issue #26 

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [x] I have added sufficient documentation and/or updated documentation to reflect my changes

# Additional comments

Would probably be better to take an `std::unordered_map<std::string, Node>` than `std::vector<std::pair<std::string, Node>>`. Feel free to tell your opinion down below.
