### PR TITLE
Request structure documentation 

### DIFF
--- a/docs/examples/REDIRECTION.md
+++ b/docs/examples/REDIRECTION.md
@@ -16,7 +16,7 @@ We'll then get the following response:
 ```
 HTTP/1.1 301 Moved Permanently
 Location: www.google.com
-``` 
+```
 
 ## Tutorial
 
@@ -37,9 +37,9 @@ public:
 
     [[nodiscard]] const char *GetDescription() const noexcept { return "Redirects the request to another location."; }
 
-    [[nodiscard]] double GetHandlerPriority() const noexcept { 
+    [[nodiscard]] double GetHandlerPriority() const noexcept {
         // Directions should be treated in priority
-        return 0.9; 
+        return 0.9;
     }
 
     void Handle(ziapi::http::Context &ctx, const ziapi::http::Request &req, ziapi::http::Response &res) override {}
@@ -81,7 +81,7 @@ Let's now implement the `Handle()` method. We simply redirect each request to th
 
 void Handle(http::Context &, const http::Request &, http::Response &res)
 {
-    res.fields[ziapi::http::header::kLocation] = redirection_route_;
+    res.headers[ziapi::http::header::kLocation] = redirection_route_;
     res.status_code = ziapi::http::code::kMovedPermanently;
 }
 

--- a/examples/modules/decompressor/DecompressorModule.hpp
+++ b/examples/modules/decompressor/DecompressorModule.hpp
@@ -31,7 +31,7 @@ public:
     [[nodiscard]] bool ShouldPreProcess(const ziapi::http::Context &, const ziapi::http::Request &req) const override
     {
         // Only use if compressed header is set
-        return req.fields.at("compressed") == std::string("true");
+        return req.headers.at("compressed") == std::string("true");
     }
 
 private:

--- a/examples/modules/redirection/Module.hpp
+++ b/examples/modules/redirection/Module.hpp
@@ -18,7 +18,7 @@ public:
     {
         /// Now we just say that the resource was moved permenatly and we indicate the new
         /// location with the redirection route.
-        res.fields[ziapi::http::header::kLocation] = redirection_route_;
+        res.headers[ziapi::http::header::kLocation] = redirection_route_;
         res.status_code = ziapi::http::Code::kMovedPermanently;
     }
 

--- a/include/ziapi/Http.hpp
+++ b/include/ziapi/Http.hpp
@@ -17,13 +17,13 @@ struct Request {
     /// For possible values of version checkout ziapi::http::Version.
     Version version;
 
-    /// For possible values of method checkout ziapi::http::method.
-    std::string method;
-
     /// The request target contains the route and the query parameters.
     /// The route is simply the path of the request, like `/users/profile`.
     /// The query parameters are the parameters of the request, like `?username=toto&age=18`.
     std::string target;
+
+    /// For possible values of method checkout ziapi::http::method.
+    std::string method;
 
     std::map<std::string, std::string> fields;
 

--- a/include/ziapi/Http.hpp
+++ b/include/ziapi/Http.hpp
@@ -25,7 +25,7 @@ struct Request {
     /// For possible values of method checkout ziapi::http::method.
     std::string method;
 
-    std::map<std::string, std::string> fields;
+    std::map<std::string, std::string> header;
 
     std::string body;
 };

--- a/include/ziapi/Http.hpp
+++ b/include/ziapi/Http.hpp
@@ -20,6 +20,9 @@ struct Request {
     /// For possible values of method checkout ziapi::http::method.
     std::string method;
 
+    /// The request target contains the route and the query parameters.
+    /// The route is simply the path of the request, like `/users/profile`.
+    /// The query parameters are the parameters of the request, like `?username=toto&age=18`.
     std::string target;
 
     std::map<std::string, std::string> fields;

--- a/include/ziapi/Http.hpp
+++ b/include/ziapi/Http.hpp
@@ -25,7 +25,7 @@ struct Request {
     /// For possible values of method checkout ziapi::http::method.
     std::string method;
 
-    std::map<std::string, std::string> header;
+    std::map<std::string, std::string> headers;
 
     std::string body;
 };

--- a/include/ziapi/Http.hpp
+++ b/include/ziapi/Http.hpp
@@ -43,7 +43,7 @@ struct Response {
     /// For possible values of version checkout ziapi::http::reason.
     std::string reason;
 
-    std::map<std::string, std::string> fields;
+    std::map<std::string, std::string> headers;
 
     std::string body;
 

--- a/tests/Compressor.cpp
+++ b/tests/Compressor.cpp
@@ -21,10 +21,10 @@ TEST(Compressor, compressionRate)
         ziapi::http::Version::kV1_1,                             // Version
         ziapi::http::Code::kOK,                                  // Status code
         std::string("OK"),                                       // reason
-        std::map<std::string, std::string>({}),                  // fields
+        std::map<std::string, std::string>({}),                  // headers
         std::string("not compressed stuff blabla omg so long"),  // body
     };
-    res.fields.insert(std::make_pair<std::string, std::string>("Content-Type", "application/json"));
+    res.headers.insert(std::make_pair<std::string, std::string>("Content-Type", "application/json"));
 
     if (compressor.ShouldPostProcess(ctx, res)) {
         compressor.PostProcess(ctx, res);

--- a/tests/Decompressor.cpp
+++ b/tests/Decompressor.cpp
@@ -21,11 +21,11 @@ TEST(Decompressor, Decompression)
         ziapi::http::Version::kV1_1,             // version
         ziapi::http::method::kPost,              // method
         "/zipper",                               // target
-        std::map<std::string, std::string>({}),  // fields
+        std::map<std::string, std::string>({}),  // hedears
         std::string("0101010110101"),            // body
     };
 
-    req.fields.insert(std::make_pair<std::string, std::string>("compressed", "true"));
+    req.headers.insert(std::make_pair<std::string, std::string>("compressed", "true"));
 
     if (decompressor.ShouldPreProcess(ctx, req)) {
         decompressor.PreProcess(ctx, req);


### PR DESCRIPTION
# Description

This PR adds some doc for the target member of the `Request` structure.
It also reorders the members so that it corresponds to the order it is in the HTTP request.
It also renames the `fields` field to `headers`.
For more explanations refer to the commits

# Breaking changes

The order change of the structure members might break some structure constructions which rely on the order of the structure members.
The name of the field `fields` changed to `headers`

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [x] I have tested this code
- [x] I have added sufficient documentation and/or updated documentation to reflect my changes
