### PR TITLE
feat: keep-alive key in http header constant

### DIFF
--- a/include/ziapi/HttpConstants.hpp
+++ b/include/ziapi/HttpConstants.hpp
@@ -99,6 +99,7 @@ constexpr auto kVary = "Vary";
 constexpr auto kWarning = "Warning";
 constexpr auto kWWWAuthenticate = "WWW-Authenticate";
 constexpr auto kXFrameOptions = "X-Frame-Options";
+constexpr auto kKeepAlive= "Keep-Alive";
 
 }  // namespace header
 


### PR DESCRIPTION
just added the key value for "keep alive"

# Description
I canot found the key "keep alive" in http header constants so i added it.

# Breaking changes

new value available in http header constants

# Additional Changes

# Checklist

- [x] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [x] I have tested this code
- [x] I have added sufficient documentation and/or updated documentation to reflect my changes

# Additional comments

Please post additional comments in this section if you have them, otherwise delete it.
