### PR TITLE
Version 3.2.0: Wait method documentation, access to request in ShouldPostProcess

### DIFF
--- a/docs/examples/LOGGER.md
+++ b/docs/examples/LOGGER.md
@@ -43,7 +43,7 @@ public:
 
     [[nodiscard]] double GetPostProcessorPriority() const noexcept override { return 1; }
 
-    [[nodiscard]] bool ShouldPostProcess(const ziapi::http::Context &ctx, const ziapi::http::Response &res) const override
+    [[nodiscard]] bool ShouldPostProcess(const ziapi::http::Context &ctx, const ziapi::http::Request req, const ziapi::http::Response &res) const override
     {
         return true;
     }

--- a/docs/general/MODULES.md
+++ b/docs/general/MODULES.md
@@ -84,7 +84,7 @@ The `GetPostProcessorPriority()` method returns the priority of the module betwe
 The `ShouldPostProcess()` method returns `true` if this module's PostProcess should be called on the response. For example you can choose that your module will only post-process responses with a status code over `399` to log them to the console!
 
 ```c++
-[[nodiscard]] virtual bool ShouldPostProcess(const http::Context &ctx, const http::Response &res) const = 0;
+[[nodiscard]] virtual bool ShouldPostProcess(const http::Context &ctx, const http::Request &req, const http::Response &res) const = 0;
 ```
 
 ## `IHandlerModule`

--- a/docs/guides/IMPLEMENT_POSTPROCESSOR.md
+++ b/docs/guides/IMPLEMENT_POSTPROCESSOR.md
@@ -13,7 +13,7 @@ public:
 
     [[nodiscard]] virtual double GetPostProcessorPriority() const noexcept = 0;
 
-    [[nodiscard]] virtual bool ShouldPostProcess(const http::Context &ctx, const http::Response &res) const = 0;
+    [[nodiscard]] virtual bool ShouldPostProcess(const http::Context &ctx, const http::Request &req, const http::Response &res) const = 0;
 };
 ```
 
@@ -34,7 +34,7 @@ public:
 
     [[nodiscard]] double GetPostProcessorPriority() const noexcept override;
 
-    [[nodiscard]] bool ShouldPostProcess(const http::Context &ctx, const http::Response &res) const override;
+    [[nodiscard]] bool ShouldPostProcess(const http::Context &ctx, const http::Request &req, const http::Response &res) const override;
 };
 ```
 
@@ -50,7 +50,7 @@ Then, let's implement the `GetPostProcessorPriority()`. Our module doesn't have 
 Then, let's implement the `ShouldPostProcess()`. This method is invoked to know if our post-processor should be called for a specific request. We can return `true` if we want all requests to go through this post-processor but let's just say our post-processor only handles `status code` inferior to 400 for the sake of the example.
 
 ```c++
-[[nodiscard]] bool ShouldPostProcess(const http::Context &ctx, const http::Response &res) const
+[[nodiscard]] bool ShouldPostProcess(const http::Context &ctx, const http::Request &req, const http::Response &res) const
 {
     return res.status_code < 400;
 }

--- a/examples/modules/compressor/CompressorModule.hpp
+++ b/examples/modules/compressor/CompressorModule.hpp
@@ -26,7 +26,8 @@ public:
         return 1.0f;
     }
 
-    [[nodiscard]] bool ShouldPostProcess(const ziapi::http::Context &, const ziapi::http::Response &) const override
+    [[nodiscard]] bool ShouldPostProcess(const ziapi::http::Context &, const ziapi::http::Request &,
+                                         const ziapi::http::Response &) const override
     {
         // Compressor will always be used as it's always useful
         return true;

--- a/examples/modules/logger/LoggerModule.hpp
+++ b/examples/modules/logger/LoggerModule.hpp
@@ -21,7 +21,7 @@ public:
 
     [[nodiscard]] double GetPostProcessorPriority() const noexcept override { return 1; }
 
-    [[nodiscard]] bool ShouldPostProcess(const ziapi::http::Context &ctx,
+    [[nodiscard]] bool ShouldPostProcess(const ziapi::http::Context &ctx, const ziapi::http::Request &req,
                                          const ziapi::http::Response &res) const override
     {
         return true;
@@ -39,12 +39,12 @@ public:
         std::stringstream ss;
 
         // Exemple: ` [X] 404: Not found (GET /test, 2s)`
-        ss << std::to_string(res.status_code) << ": " << res.reason << " (" << std::any_cast<std::string>(ctx["method"])
-           << " " << std::any_cast<std::string>(ctx["target"]) << ", " << std::setprecision(2)
-           << difftime(std::time(nullptr), std::any_cast<time_t>(ctx["timestamp"])) << "s)";
-        if (res.status_code < 300) {
+        ss << std::to_string((int)res.status_code) << ": " << res.reason << " ("
+           << std::any_cast<std::string>(ctx["method"]) << " " << std::any_cast<std::string>(ctx["target"]) << ", "
+           << std::setprecision(2) << difftime(std::time(nullptr), std::any_cast<time_t>(ctx["timestamp"])) << "s)";
+        if ((int)res.status_code < 300) {
             ziapi::Logger::Info(ss.str());
-        } else if (res.status_code < 400) {
+        } else if ((int)res.status_code < 400) {
             ziapi::Logger::Warning(ss.str());
         } else {
             ziapi::Logger::Error(ss.str());

--- a/include/ziapi/Http.hpp
+++ b/include/ziapi/Http.hpp
@@ -72,6 +72,8 @@ public:
 
     [[nodiscard]] virtual std::size_t Size() const noexcept = 0;
 
+    // Wait is used to wait until something is available in the queue and return once that's the case.
+    // It is a blocking call
     virtual void Wait() noexcept = 0;
 };
 

--- a/include/ziapi/Module.hpp
+++ b/include/ziapi/Module.hpp
@@ -74,7 +74,8 @@ public:
     /**
      *  Whether this module's PostProcess should be called on the response
      */
-    [[nodiscard]] virtual bool ShouldPostProcess(const http::Context &ctx, const http::Response &res) const = 0;
+    [[nodiscard]] virtual bool ShouldPostProcess(const http::Context &ctx, const http::Request &req,
+                                                 const http::Response &res) const = 0;
 };
 
 /**

--- a/tests/Compressor.cpp
+++ b/tests/Compressor.cpp
@@ -16,7 +16,8 @@ TEST(Compressor, UtilsInfo)
 TEST(Compressor, compressionRate)
 {
     CompressorModule compressor;
-    ziapi::http::Context ctx;
+    ziapi::http::Context ctx{};
+    ziapi::http::Request req{};
     ziapi::http::Response res = {
         ziapi::http::Version::kV1_1,                             // Version
         ziapi::http::Code::kOK,                                  // Status code
@@ -26,7 +27,7 @@ TEST(Compressor, compressionRate)
     };
     res.headers.insert(std::make_pair<std::string, std::string>("Content-Type", "application/json"));
 
-    if (compressor.ShouldPostProcess(ctx, res)) {
+    if (compressor.ShouldPostProcess(ctx, req, res)) {
         compressor.PostProcess(ctx, res);
     }
     ASSERT_EQ(res.body, "not compressed stuf");


### PR DESCRIPTION
Wait method on input queue is now documented with a comment.

# Breaking changes

ShouldPostProcess now takes the request as parameter.
Updated documentation accordingly.

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [x] I have added sufficient documentation and/or updated documentation to reflect my changes