### PR TITLE
Version 5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Banner](docs/assets/project_banner.png)
 
-[![ZiAPI](https://img.shields.io/badge/ZiAPI-v4.0.0-blue.svg)](https://github.com/martin-olivier/ZiAPI/releases/tag/v4.0.0)
+[![ZiAPI](https://img.shields.io/badge/ZiAPI-v5.0.0-blue.svg)](https://github.com/martin-olivier/ZiAPI/releases/tag/v5.0.0)
 [![CPP Version](https://img.shields.io/badge/C++-17_and_above-darkgreen.svg)](https://isocpp.org/)
 [![Discord](https://img.shields.io/discord/934852777136513075)](https://discord.gg/CzKv6dGXmf)
 [![workflow](https://github.com/martin-olivier/ZiAPI/actions/workflows/CI.yml/badge.svg)](https://github.com/martin-olivier/ZiAPI/actions/workflows/CI.yml)
@@ -38,7 +38,7 @@ include(ExternalProject)
 ExternalProject_Add(
     ziapi
     GIT_REPOSITORY  https://github.com/martin-olivier/ZiAPI.git
-    GIT_TAG         v4.0.0
+    GIT_TAG         v5.0.0
     INSTALL_COMMAND ""
     TEST_COMMAND    ""
 )

--- a/docs/examples/LOGGER.md
+++ b/docs/examples/LOGGER.md
@@ -66,6 +66,7 @@ Then, first thing we want is to store the timestamp when the request is received
 void PreProcess(ziapi::http::Context &ctx, ziapi::http::Request &req) override
 {
     ctx["timestamp"] = std::time(nullptr);
+    // This example is deprecated. The `PostProcess` method has access to the request since version 5.0.0.
     ctx["target"] = req.target;
     ctx["method"] = req.method;
 }
@@ -76,7 +77,7 @@ And now in the post-process we can just simply access our variables and use them
 ```cpp
 ...
 
-void PostProcess(ziapi::http::Context &ctx, ziapi::http::Response &res) override
+void PostProcess(ziapi::http::Context &ctx, const ziapi::http::Request &, ziapi::http::Response &res) override
 {
     std::stringstream ss;
 

--- a/docs/general/MODULES.md
+++ b/docs/general/MODULES.md
@@ -72,7 +72,7 @@ The `ShouldPreProcess()` method returns `true` if this module's PreProcess metho
 The `PostProcess()` is the method invoked on a response after the handler is called. You can use post-processors to modify the response after it is generated (serializing the body, logging the response, etc...).
 
 ```c++
-virtual void PostProcess(http::Context &ctx, http::Response &res) = 0;
+virtual void PostProcess(http::Context &ctx, const http::Request &, http::Response &res) = 0;
 ```
 
 The `GetPostProcessorPriority()` method returns the priority of the module between zero and one. Post-processors with a higher priority are executed first!

--- a/docs/guides/INSTALL_AND_BUILD.md
+++ b/docs/guides/INSTALL_AND_BUILD.md
@@ -11,7 +11,7 @@ include(ExternalProject)
 ExternalProject_Add(
     ziapi
     GIT_REPOSITORY  https://github.com/martin-olivier/ZiAPI.git
-    GIT_TAG         v4.0.0
+    GIT_TAG         v5.0.0
     INSTALL_COMMAND ""
     TEST_COMMAND    ""
 )

--- a/docs/guides/MODULES_101.md
+++ b/docs/guides/MODULES_101.md
@@ -42,7 +42,7 @@ include(ExternalProject)
 ExternalProject_Add(
     ziapi
     GIT_REPOSITORY  https://github.com/martin-olivier/ZiAPI.git
-    GIT_TAG         v4.0.0
+    GIT_TAG         v5.0.0
     INSTALL_COMMAND ""
     TEST_COMMAND    ""
 )

--- a/examples/modules/compressor/CompressorModule.hpp
+++ b/examples/modules/compressor/CompressorModule.hpp
@@ -18,7 +18,10 @@ public:
         return "Compress the response body before sending it back to the network";
     }
 
-    void PostProcess(ziapi::http::Context &, ziapi::http::Response &res) override { res.body = CompressBody(res.body); }
+    void PostProcess(ziapi::http::Context &, const ziapi::http::Request &, ziapi::http::Response &res) override
+    {
+        res.body = CompressBody(res.body);
+    }
 
     [[nodiscard]] double GetPostProcessorPriority() const noexcept override
     {

--- a/examples/modules/logger/LoggerModule.hpp
+++ b/examples/modules/logger/LoggerModule.hpp
@@ -34,7 +34,7 @@ public:
         return true;
     }
 
-    void PostProcess(ziapi::http::Context &ctx, ziapi::http::Response &res) override
+    void PostProcess(ziapi::http::Context &ctx, const ziapi::http::Request &, ziapi::http::Response &res) override
     {
         std::stringstream ss;
 
@@ -54,6 +54,8 @@ public:
     void PreProcess(ziapi::http::Context &ctx, ziapi::http::Request &req) override
     {
         ctx["timestamp"] = std::time(nullptr);
+        /// This example is deprecrated. Storing the target and method is useless because the `PostProcess` method now
+        /// has access to the request object.
         ctx["target"] = req.target;
         ctx["method"] = req.method;
     }

--- a/include/ziapi/Http.hpp
+++ b/include/ziapi/Http.hpp
@@ -66,9 +66,11 @@ using Context = std::unordered_map<std::string, std::any>;
  */
 class IResponseInputQueue {
 public:
+    using ValueType = std::pair<Response, Context>;
+
     virtual ~IResponseInputQueue() = default;
 
-    [[nodiscard]] virtual std::optional<std::pair<Response, Context>> Pop() = 0;
+    [[nodiscard]] virtual std::optional<ValueType> Pop() = 0;
 
     [[nodiscard]] virtual std::size_t Size() const noexcept = 0;
 
@@ -82,9 +84,11 @@ public:
  */
 class IRequestOutputQueue {
 public:
+    using ValueType = std::pair<Request, Context>;
+
     virtual ~IRequestOutputQueue() = default;
 
-    virtual void Push(std::pair<Request, Context> &&req) = 0;
+    virtual void Push(ValueType &&req) = 0;
 
     [[nodiscard]] virtual std::size_t Size() const noexcept = 0;
 };

--- a/include/ziapi/Module.hpp
+++ b/include/ziapi/Module.hpp
@@ -63,7 +63,7 @@ public:
     /**
      *  Handler invoked during the post-processing pipeline after the handler.
      */
-    virtual void PostProcess(http::Context &ctx, http::Response &res) = 0;
+    virtual void PostProcess(http::Context &ctx, const http::Request &req, http::Response &res) = 0;
 
     /**
      *  Value between zero and one which states the module's priority of

--- a/tests/Compressor.cpp
+++ b/tests/Compressor.cpp
@@ -28,7 +28,7 @@ TEST(Compressor, compressionRate)
     res.headers.insert(std::make_pair<std::string, std::string>("Content-Type", "application/json"));
 
     if (compressor.ShouldPostProcess(ctx, req, res)) {
-        compressor.PostProcess(ctx, res);
+        compressor.PostProcess(ctx, req, res);
     }
     ASSERT_EQ(res.body, "not compressed stuf");
 }

--- a/tests/Config.cpp
+++ b/tests/Config.cpp
@@ -81,10 +81,10 @@ TEST(Config, VectorConstructArray)
     ASSERT_EQ(n[2].AsDouble(), 1.f);
 }
 
-TEST(Config, VectorConstructDict)
+TEST(Config, MapConstructDict)
 {
-    std::unordered_map<std::string, Node> vec{{"ten", 10}, {"string", "value"}, {"float", 1.f}, {"null", nullptr}};
-    Node n = Node::MakeDict(vec);
+    std::unordered_map<std::string, Node> map{{"ten", 10}, {"string", "value"}, {"float", 1.f}, {"null", nullptr}};
+    Node n = Node::MakeDict(map);
 
     ASSERT_EQ(n["ten"].AsInt(), 10);
     ASSERT_EQ(n["string"].AsString(), "value");

--- a/tests/Logger.cpp
+++ b/tests/Logger.cpp
@@ -27,7 +27,7 @@ public:
     }
 };
 
-TEST(Logger, info)
+TEST(Logger, Info)
 {
     OSRedirector os(std::cout);
 
@@ -37,7 +37,7 @@ TEST(Logger, info)
                 std::string::npos);
 }
 
-TEST(Logger, warning)
+TEST(Logger, Warning)
 {
     OSRedirector os(std::cout);
 
@@ -47,7 +47,7 @@ TEST(Logger, warning)
                 std::string::npos);
 }
 
-TEST(Logger, error)
+TEST(Logger, Error)
 {
     OSRedirector os(std::cerr);
 
@@ -57,7 +57,7 @@ TEST(Logger, error)
                 std::string::npos);
 }
 
-TEST(Logger, debug)
+TEST(Logger, Debug)
 {
     OSRedirector os(std::cout);
 
@@ -67,7 +67,7 @@ TEST(Logger, debug)
                 std::string::npos);
 }
 
-TEST(Logger, variadic)
+TEST(Logger, Variadic)
 {
     OSRedirector os(std::cout);
 

--- a/tests/Module.cpp
+++ b/tests/Module.cpp
@@ -5,7 +5,7 @@
 #include "dylib/dylib.hpp"
 #include "ziapi/Logger.hpp"
 
-TEST(Module, example)
+TEST(Module, Example)
 {
     try {
         dylib lib("./module", dylib::extension);

--- a/tests/Version.cpp
+++ b/tests/Version.cpp
@@ -2,7 +2,7 @@
 
 #include <gtest/gtest.h>
 
-TEST(Version, equal)
+TEST(Version, Equal)
 {
     ziapi::Version a{1, 0, 3};
     ziapi::Version b{1, 0, 3};
@@ -20,7 +20,7 @@ TEST(Version, equal)
     ASSERT_FALSE(a == b);
 }
 
-TEST(Version, not_equal)
+TEST(Version, NotEqual)
 {
     ziapi::Version a{1, 0, 0};
     ziapi::Version b{1, 0, 0};
@@ -38,7 +38,7 @@ TEST(Version, not_equal)
     ASSERT_TRUE(a != b);
 }
 
-TEST(Version, greater)
+TEST(Version, Greater)
 {
     ziapi::Version a{1, 0, 3};
     ziapi::Version b{1, 0, 3};
@@ -56,7 +56,7 @@ TEST(Version, greater)
     ASSERT_FALSE(a > b);
 }
 
-TEST(Version, less)
+TEST(Version, Less)
 {
     ziapi::Version a{1, 0, 1};
     ziapi::Version b{1, 0, 0};
@@ -74,7 +74,7 @@ TEST(Version, less)
     ASSERT_FALSE(a < b);
 }
 
-TEST(Version, greater_or_equal)
+TEST(Version, GreaterOrEqual)
 {
     ziapi::Version a{1, 0, 0};
     ziapi::Version b{1, 0, 0};
@@ -92,7 +92,7 @@ TEST(Version, greater_or_equal)
     ASSERT_FALSE(a >= b);
 }
 
-TEST(Version, less_or_equal)
+TEST(Version, LessOrEqual)
 {
     ziapi::Version a{1, 0, 0};
     ziapi::Version b{1, 0, 0};


### PR DESCRIPTION
# Description

Changes to be introduced in version 5.0.0 of ZIAPI.

# Breaking changes

- `IPostProcessorModule::PostProcess` now takes a `const ziapi::http::Request &` object as its second positional argument.
- Add `ziapi::http::RequestInputQueue::ValueType`  and `ziapi::http::ResponseOutputQueue::ValueType` 

# Additional Changes

- Review naming conventions for unit test descriptions.

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [x] I have added sufficient documentation and/or updated documentation to reflect my changes