### PR TITLE
fix: missing virtual inheritance for IHandlerModule & INetworkModule

### DIFF
--- a/include/ziapi/Module.hpp
+++ b/include/ziapi/Module.hpp
@@ -29,7 +29,7 @@ public:
  *  the contents of the response such as a directory listing module, a web
  *  server module, etc...
  */
-class IHandlerModule : public IModule {
+class IHandlerModule : virtual public IModule {
 public:
     virtual ~IHandlerModule() = default;
 


### PR DESCRIPTION
# Description

Add a missing virtual in `IHandlerModule` inheritance.

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [ ] I have tested this code
- [x] I have added sufficient documentation and/or updated documentation to reflect my changes

